### PR TITLE
Adds for ministries

### DIFF
--- a/auto/assembly.sh
+++ b/auto/assembly.sh
@@ -3,6 +3,7 @@
 SCRIPT=$( cd "$( dirname "$0" )" && pwd )/../public/index.php
 
 php ${SCRIPT} load:congressman --assembly=$1
+php ${SCRIPT} load:minister --assembly=$1
 php ${SCRIPT} load:plenary --assembly=$1
 php ${SCRIPT} load:issue --assembly=$1
 php ${SCRIPT} load:tmp-speech --assembly=$1

--- a/auto/globals.sh
+++ b/auto/globals.sh
@@ -3,6 +3,7 @@
 SCRIPT=$( cd "$( dirname "$0" )" && pwd )/../public/index.php
 
 php ${SCRIPT} load:assembly
+php ${SCRIPT} load:ministry
 php ${SCRIPT} load:party
 php ${SCRIPT} load:constituency
 php ${SCRIPT} load:committee

--- a/module/AlthingiAggregator/config/module.config.php
+++ b/module/AlthingiAggregator/config/module.config.php
@@ -86,6 +86,11 @@ return [
                     ->setConsumer($container->get('Consumer'))
                     ->setProvider($container->get('Provider'));
             },
+            Controller\MinistryController::class => function ($container) {
+                return (new Controller\MinistryController())
+                    ->setConsumer($container->get('Consumer'))
+                    ->setProvider($container->get('Provider'));
+            },
         ],
     ],
     'console' => [
@@ -142,6 +147,24 @@ return [
                         'defaults' => [
                             'controller' => Controller\CongressmanController::class,
                             'action'     => 'find-congressman'
+                        ]
+                    ]
+                ],
+                'minister' => [
+                    'options' => [
+                        'route'    => 'load:minister [--assembly=|-a]',
+                        'defaults' => [
+                            'controller' => Controller\CongressmanController::class,
+                            'action'     => 'find-minister'
+                        ]
+                    ]
+                ],
+                'ministry' => [
+                    'options' => [
+                        'route'    => 'load:ministry',
+                        'defaults' => [
+                            'controller' => Controller\MinistryController::class,
+                            'action'     => 'find-ministry'
                         ]
                     ]
                 ],

--- a/module/AlthingiAggregator/src/Controller/CongressmanController.php
+++ b/module/AlthingiAggregator/src/Controller/CongressmanController.php
@@ -71,9 +71,7 @@ class CongressmanController extends AbstractActionController implements Consumer
      * for given assembly will be fetched.
      *
      * If no additional params is given, only the congressmen are fetched but not
-     * their session in parliment.
-     *
-     * //https://www.althingi.is/altext/xml/radherrar/?lthing=149
+     * their session in parliament.
      *
      * @throws \Exception
      */

--- a/module/AlthingiAggregator/src/Controller/CongressmanController.php
+++ b/module/AlthingiAggregator/src/Controller/CongressmanController.php
@@ -2,6 +2,7 @@
 namespace AlthingiAggregator\Controller;
 
 use AlthingiAggregator\Extractor\CommitteeSitting;
+use AlthingiAggregator\Extractor\MinisterSitting;
 use Zend\Mvc\Controller\AbstractActionController;
 use AlthingiAggregator\Lib\Consumer\ConsumerAwareInterface;
 use AlthingiAggregator\Lib\Provider\ProviderAwareInterface;
@@ -59,6 +60,60 @@ class CongressmanController extends AbstractActionController implements Consumer
                     "thingmenn/{$congressmanId}/nefndaseta",
                     '//þingmaður/nefndasetur/nefndaseta',
                     new CommitteeSitting()
+                );
+            }
+        }
+    }
+
+    /**
+     * Get Ministers.
+     * If additional parameter is passed (--assembly=int) than only congressman
+     * for given assembly will be fetched.
+     *
+     * If no additional params is given, only the congressmen are fetched but not
+     * their session in parliment.
+     *
+     * //https://www.althingi.is/altext/xml/radherrar/?lthing=149
+     *
+     * @throws \Exception
+     */
+    public function findMinisterAction()
+    {
+        $assemblyNumber = $this->params('assembly', null);
+        $congressmenUrl = ($assemblyNumber)
+            ? "https://www.althingi.is/altext/xml/radherrar/?lthing={$assemblyNumber}"
+            : "https://www.althingi.is/altext/xml/radherrar";
+        $congressmenElements = $this->queryForNoteList($congressmenUrl, '//ráðherralisti/ráðherra');
+
+        $this->saveDomNodeList(
+            $congressmenElements,
+            'thingmenn',
+            new Congressman()
+        );
+
+        if ($assemblyNumber) {
+            /** @var  $congressmanElement \DOMElement*/
+            foreach ($congressmenElements as $congressmanElement) {
+                $congressmanId = $congressmanElement->getAttribute('id');
+                $congressmanSessionUrl = trim(
+                    $congressmanElement->getElementsByTagName('þingseta')->item(0)->nodeValue //http://www.althingi.is/altext/xml/thingmenn/thingmadur/thingseta/?nr=1261
+                );
+                $congressmanCommitteeUrl = trim(
+                    $congressmanElement->getElementsByTagName('ráðherraseta')->item(0)->nodeValue //https://www.althingi.is/altext/xml/radherrar/radherraseta/?nr=1261
+                );
+
+                $this->queryAndSave(
+                    $congressmanSessionUrl,
+                    "thingmenn/{$congressmanId}/thingseta",
+                    '//þingmaður/þingsetur/þingseta',
+                    new Session()
+                );
+
+                $this->queryAndSave(
+                    $congressmanCommitteeUrl,
+                    "thingmenn/{$congressmanId}/radherraseta",
+                    '//einstaklingur/ráðherrasetur/ráðherraseta',
+                    new MinisterSitting()
                 );
             }
         }

--- a/module/AlthingiAggregator/src/Controller/MinistryController.php
+++ b/module/AlthingiAggregator/src/Controller/MinistryController.php
@@ -1,0 +1,22 @@
+<?php
+namespace AlthingiAggregator\Controller;
+
+use AlthingiAggregator\Extractor\Ministry;
+use Zend\Mvc\Controller\AbstractActionController;
+use AlthingiAggregator\Lib\Consumer\ConsumerAwareInterface;
+use AlthingiAggregator\Lib\Provider\ProviderAwareInterface;
+
+class MinistryController extends AbstractActionController implements ConsumerAwareInterface, ProviderAwareInterface
+{
+    use ConsoleHelper;
+
+    public function findMinistryAction()
+    {
+        $this->queryAndSave(
+            'https://www.althingi.is/altext/xml/radherraembaetti',
+            'radherraembaetti',
+            '//ráðherrar/ráðherraembætti',
+            new Ministry()
+        );
+    }
+}

--- a/module/AlthingiAggregator/src/Extractor/MinisterSitting.php
+++ b/module/AlthingiAggregator/src/Extractor/MinisterSitting.php
@@ -1,0 +1,74 @@
+<?php
+namespace AlthingiAggregator\Extractor;
+
+use AlthingiAggregator\Lib\IdentityInterface;
+use AlthingiAggregator\Extractor\Exception as ModelException;
+
+class MinisterSitting implements ExtractionInterface
+{
+    /**
+     * @param \DOMElement $object
+     * @return array
+     * @throws ModelException
+     */
+    public function extract(\DOMElement $object)
+    {
+        /*
+         * <ráðherraseta>
+            <þing>149</þing>
+            <skammstöfun>ÁslS</skammstöfun>
+            <embætti id="224">dómsmálaráðherra</embætti>
+            <þingflokkur id="35">Sjálfstæðisflokkur</þingflokkur>
+            <tímabil>
+            <inn>06.09.2019</inn>
+            <út>09.09.2019</út>
+            </tímabil>
+            </ráðherraseta>
+         */
+
+        $assembly = $object->getElementsByTagName('þing')->length === 1
+            ? $object->getElementsByTagName('þing')->item(0)->nodeValue
+            : null;
+        if (! $assembly) {
+            throw new ModelException('Missing [{þing}] value', $object);
+        }
+
+        $ministry = $object->getElementsByTagName('embætti')->length === 1
+            ? $object->getElementsByTagName('embætti')->item(0)->getAttribute('id')
+            : null;
+        if (! $assembly) {
+            throw new ModelException('Missing [{embætti}] value', $object);
+        }
+
+        $party = $object->getElementsByTagName('þingflokkur')->length === 1
+            ? $object->getElementsByTagName('þingflokkur')->item(0)->getAttribute('id')
+            : null;
+
+        $from = $object->getElementsByTagName('inn')->length === 1
+            ? $object->getElementsByTagName('inn')->item(0)->nodeValue
+            : null;
+        $to = $object->getElementsByTagName('út')->length === 1
+            ? $object->getElementsByTagName('út')->item(0)->nodeValue
+            : null ;
+
+        if ($from) {
+            $result = [];
+            $match = preg_match('/([0-9]{2})\.([0-9]{2})\.([0-9]{4})/', $from, $result);
+            $from = $match !== false ? "{$result[3]}-{$result[2]}-{$result[1]}" : null;
+        }
+
+        if ($to) {
+            $result = [];
+            $match = preg_match('/([0-9]{2})\.([0-9]{2})\.([0-9]{4})/', $to, $result);
+            $to = $match !== false ? "{$result[3]}-{$result[2]}-{$result[1]}" : null;
+        }
+
+        return [
+            'assembly_id' => $assembly,
+            'ministry_id' => $ministry,
+            'party_id' => $party,
+            'from' => $from,
+            'to' => $to,
+        ];
+    }
+}

--- a/module/AlthingiAggregator/src/Extractor/MinisterSitting.php
+++ b/module/AlthingiAggregator/src/Extractor/MinisterSitting.php
@@ -13,35 +13,22 @@ class MinisterSitting implements ExtractionInterface
      */
     public function extract(\DOMElement $object)
     {
-        /*
-         * <ráðherraseta>
-            <þing>149</þing>
-            <skammstöfun>ÁslS</skammstöfun>
-            <embætti id="224">dómsmálaráðherra</embætti>
-            <þingflokkur id="35">Sjálfstæðisflokkur</þingflokkur>
-            <tímabil>
-            <inn>06.09.2019</inn>
-            <út>09.09.2019</út>
-            </tímabil>
-            </ráðherraseta>
-         */
-
         $assembly = $object->getElementsByTagName('þing')->length === 1
-            ? $object->getElementsByTagName('þing')->item(0)->nodeValue
+            ? (int) $object->getElementsByTagName('þing')->item(0)->nodeValue
             : null;
         if (! $assembly) {
             throw new ModelException('Missing [{þing}] value', $object);
         }
 
         $ministry = $object->getElementsByTagName('embætti')->length === 1
-            ? $object->getElementsByTagName('embætti')->item(0)->getAttribute('id')
+            ? (int) $object->getElementsByTagName('embætti')->item(0)->getAttribute('id')
             : null;
         if (! $assembly) {
             throw new ModelException('Missing [{embætti}] value', $object);
         }
 
         $party = $object->getElementsByTagName('þingflokkur')->length === 1
-            ? $object->getElementsByTagName('þingflokkur')->item(0)->getAttribute('id')
+            ? (int) $object->getElementsByTagName('þingflokkur')->item(0)->getAttribute('id')
             : null;
 
         $from = $object->getElementsByTagName('inn')->length === 1

--- a/module/AlthingiAggregator/src/Extractor/Ministry.php
+++ b/module/AlthingiAggregator/src/Extractor/Ministry.php
@@ -1,0 +1,62 @@
+<?php
+namespace AlthingiAggregator\Extractor;
+
+use DOMElement;
+use AlthingiAggregator\Lib\IdentityInterface;
+use AlthingiAggregator\Extractor\Exception as ModelException;
+
+class Ministry implements ExtractionInterface, IdentityInterface
+{
+    private $id;
+
+    /**
+     * Extract values from an object
+     *
+     * @param  DOMElement $object
+     * @return array|null
+     * @throws \AlthingiAggregator\Extractor\Exception
+     */
+    public function extract(DOMElement $object)
+    {
+        if (! $object->hasAttribute('id')) {
+            throw new ModelException('Missing [{id}] value', $object);
+        }
+
+        $this->setIdentity($object->getAttribute('id'));
+
+        $name = $object->getElementsByTagName('heiti')->length === 1
+            ? trim($object->getElementsByTagName('heiti')->item(0)->nodeValue)
+            : null;
+        $abbrShort = $object->getElementsByTagName('stuttskammstöfun')->length === 1
+            ? trim($object->getElementsByTagName('stuttskammstöfun')->item(0)->nodeValue)
+            : null;
+        $abbrLong = $object->getElementsByTagName('löngskammstöfun')->length === 1
+            ? trim($object->getElementsByTagName('löngskammstöfun')->item(0)->nodeValue)
+            : null;
+        $first = $object->getElementsByTagName('fyrstaþing')->length === 1
+            ? trim($object->getElementsByTagName('fyrstaþing')->item(0)->nodeValue)
+            : null;
+        $last = $object->getElementsByTagName('síðastaþing')->length === 1
+            ? trim($object->getElementsByTagName('síðastaþing')->item(0)->nodeValue)
+            : null;
+
+        return [
+            'ministry_id' => (int) $this->getIdentity(),
+            'name' => $name,
+            'abbr_short' => $abbrShort,
+            'abbr_slong' => $abbrLong,
+            'first' => empty($first) ? null : (int) $first,
+            'last' => empty($last) ? null : (int) $last,
+        ];
+    }
+
+    public function setIdentity($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getIdentity()
+    {
+        return $this->id;
+    }
+}

--- a/module/AlthingiAggregator/tests/Controller/CongressmanControllerTest.php
+++ b/module/AlthingiAggregator/tests/Controller/CongressmanControllerTest.php
@@ -312,39 +312,40 @@ class CongressmanControllerTest extends AbstractConsoleControllerTestCase
     {
         $source = '<?xml version="1.0" encoding="UTF-8"?>
                 <einstaklingur id=\'1261\'>
-                <nafn>Áslaug Arna Sigurbjörnsdóttir</nafn>
-                <xml>
-                <lífshlaup>http://www.althingi.is/altext/xml/thingmenn/thingmadur/lifshlaup/?nr=1261</lífshlaup>
-                <hagsmunir>http://www.althingi.is/altext/xml/thingmenn/thingmadur/hagsmunir/?nr=1261</hagsmunir>
-                <þingseta>http://www.althingi.is/altext/xml/thingmenn/thingmadur/thingseta/?nr=1261</þingseta>
-                <ráðherraseta>http://www.althingi.is/altext/xml/radherrar/radherraseta/?nr=1261</ráðherraseta>
-                </xml>
-                <html>
-                <lífshlaup>http://www.althingi.is/altext/cv/?nfaerslunr=1261</lífshlaup>
-                <hagsmunir>http://www.althingi.is/altext/hagsmunir/?faerslunr=1261</hagsmunir>
-                <þingstörf>http://www.althingi.is/vefur/thmstorf.html?nfaerslunr=1261</þingstörf>
-                </html>
-                
-                <ráðherrasetur>
-                <ráðherraseta>
-                <þing>149</þing>
-                <skammstöfun>ÁslS</skammstöfun>
-                <embætti id=\'224\'>dómsmálaráðherra</embætti>
-                <þingflokkur id=\'35\'>Sjálfstæðisflokkur</þingflokkur>
-                <tímabil>
-                <inn>06.09.2019</inn><út>09.09.2019</út></tímabil>
-                </ráðherraseta>
-                
-                <ráðherraseta>
-                <þing>150</þing>
-                <skammstöfun>ÁslS</skammstöfun>
-                <embætti id=\'224\'>dómsmálaráðherra</embætti>
-                <þingflokkur id=\'35\'>Sjálfstæðisflokkur</þingflokkur>
-                <tímabil>
-                <inn>10.09.2019</inn><út></út></tímabil>
-                </ráðherraseta>
-                
-                </ráðherrasetur>
+                    <nafn>Áslaug Arna Sigurbjörnsdóttir</nafn>
+                    <xml>
+                        <lífshlaup>http://www.althingi.is/altext/xml/thingmenn/thingmadur/lifshlaup/?nr=1261</lífshlaup>
+                        <hagsmunir>http://www.althingi.is/altext/xml/thingmenn/thingmadur/hagsmunir/?nr=1261</hagsmunir>
+                        <þingseta>http://www.althingi.is/altext/xml/thingmenn/thingmadur/thingseta/?nr=1261</þingseta>
+                        <ráðherraseta>http://www.althingi.is/altext/xml/radherrar/radherraseta/?nr=1261</ráðherraseta>
+                    </xml>
+                    <html>
+                        <lífshlaup>http://www.althingi.is/altext/cv/?nfaerslunr=1261</lífshlaup>
+                        <hagsmunir>http://www.althingi.is/altext/hagsmunir/?faerslunr=1261</hagsmunir>
+                        <þingstörf>http://www.althingi.is/vefur/thmstorf.html?nfaerslunr=1261</þingstörf>
+                    </html>
+                    <ráðherrasetur>
+                        <ráðherraseta>
+                            <þing>149</þing>
+                            <skammstöfun>ÁslS</skammstöfun>
+                            <embætti id=\'224\'>dómsmálaráðherra</embætti>
+                            <þingflokkur id=\'35\'>Sjálfstæðisflokkur</þingflokkur>
+                            <tímabil>
+                                <inn>06.09.2019</inn>
+                                <út>09.09.2019</út>
+                            </tímabil>
+                        </ráðherraseta>
+                        <ráðherraseta>
+                            <þing>150</þing>
+                            <skammstöfun>ÁslS</skammstöfun>
+                            <embætti id=\'224\'>dómsmálaráðherra</embætti>
+                            <þingflokkur id=\'35\'>Sjálfstæðisflokkur</þingflokkur>
+                            <tímabil>
+                                <inn>10.09.2019</inn>
+                                <út></út>
+                            </tímabil>
+                        </ráðherraseta>
+                    </ráðherrasetur>
                 </einstaklingur>
                 ';
         $dom = new \DOMDocument();

--- a/module/AlthingiAggregator/tests/Controller/CongressmanControllerTest.php
+++ b/module/AlthingiAggregator/tests/Controller/CongressmanControllerTest.php
@@ -88,6 +88,60 @@ class CongressmanControllerTest extends AbstractConsoleControllerTestCase
         $this->assertArrayHasKey('thingmenn/648/nefndaseta', $consumerStoredData);
     }
 
+    public function testMinisterRoute()
+    {
+        $this->provider->addDocument(
+            'https://www.althingi.is/altext/xml/radherrar',
+            $this->getMinisterDomDocument()
+        );
+
+        $this->dispatch('load:minister');
+
+        $this->assertControllerName(Controller\CongressmanController::class);
+        $this->assertActionName('find-minister');
+    }
+
+    public function testSessionAndMinister()
+    {
+        $this->provider->addDocument(
+            'https://www.althingi.is/altext/xml/radherrar/?lthing=1',
+            $this->getMinisterDomDocument()
+        );
+        $this->provider->addDocument(
+            'http://www.althingi.is/altext/xml/thingmenn/thingmadur/thingseta/?nr=1261',
+            $this->getSessionDocument()
+        );
+        $this->provider->addDocument(
+            'http://www.althingi.is/altext/xml/thingmenn/thingmadur/thingseta/?nr=707',
+            $this->getSessionDocument()
+        );
+        $this->provider->addDocument(
+            'http://www.althingi.is/altext/xml/radherrar/radherraseta/?nr=1261',
+            $this->getMinisterSession()
+        );
+        $this->provider->addDocument(
+            'http://www.althingi.is/altext/xml/radherrar/radherraseta/?nr=707',
+            $this->getMinisterSession()
+        );
+
+        $this->dispatch('load:minister --assembly=1');
+
+        $expected = [
+            'thingmenn/1261',
+            'thingmenn/707',
+            'thingmenn/1261/thingseta',
+            'thingmenn/1261/radherraseta',
+            'thingmenn/707/thingseta',
+            'thingmenn/707/radherraseta'
+        ];
+
+        $i = array_keys($this->consumer->getObjects());
+
+        $this->assertControllerName(Controller\CongressmanController::class);
+        $this->assertActionName('find-minister');
+        $this->assertEquals($expected, array_keys($this->consumer->getObjects()));
+    }
+
     public function getDomDocument()
     {
         $source = '<?xml version="1.0" encoding="UTF-8"?>
@@ -206,6 +260,93 @@ class CongressmanControllerTest extends AbstractConsoleControllerTestCase
                </nefndasetur>
             </þingmaður>
         ';
+        $dom = new \DOMDocument();
+        $dom->loadXML($source);
+        return $dom;
+    }
+
+    public function getMinisterDomDocument()
+    {
+        $source = '<?xml version="1.0" encoding="UTF-8"?>
+            <ráðherralisti>
+                <ráðherra id=\'1261\'>
+                    <nafn>Áslaug Arna Sigurbjörnsdóttir</nafn>
+                    <fæðingardagur>1990-11-30</fæðingardagur>
+                    <xml>
+                        <nánar>http://www.althingi.is/altext/xml/thingmenn/thingmadur/?nr=1261</nánar>
+                        <lífshlaup>http://www.althingi.is/altext/xml/thingmenn/thingmadur/lifshlaup/?nr=1261</lífshlaup>
+                        <hagsmunir>http://www.althingi.is/altext/xml/thingmenn/thingmadur/hagsmunir/?nr=1261</hagsmunir>
+                        <þingseta>http://www.althingi.is/altext/xml/thingmenn/thingmadur/thingseta/?nr=1261</þingseta>
+                        <ráðherraseta>http://www.althingi.is/altext/xml/radherrar/radherraseta/?nr=1261</ráðherraseta>
+                    </xml>
+                    <html>
+                        <lífshlaup>http://www.althingi.is/altext/cv/?nfaerslunr=1261</lífshlaup>
+                        <hagsmunir>http://www.althingi.is/altext/hagsmunir/?faerslunr=1261</hagsmunir>
+                        <þingstörf>http://www.althingi.is/vefur/thmstorf.html?nfaerslunr=1261</þingstörf>
+                    </html>
+                </ráðherra>
+            
+                <ráðherra id=\'707\'>
+                    <nafn>Ásmundur Einar Daðason</nafn>
+                    <fæðingardagur>1982-10-29</fæðingardagur>
+                    <xml>
+                        <nánar>http://www.althingi.is/altext/xml/thingmenn/thingmadur/?nr=707</nánar>
+                        <lífshlaup>http://www.althingi.is/altext/xml/thingmenn/thingmadur/lifshlaup/?nr=707</lífshlaup>
+                        <hagsmunir>http://www.althingi.is/altext/xml/thingmenn/thingmadur/hagsmunir/?nr=707</hagsmunir>
+                        <þingseta>http://www.althingi.is/altext/xml/thingmenn/thingmadur/thingseta/?nr=707</þingseta>
+                        <ráðherraseta>http://www.althingi.is/altext/xml/radherrar/radherraseta/?nr=707</ráðherraseta>
+                    </xml>
+                    <html>
+                        <lífshlaup>http://www.althingi.is/altext/cv/?nfaerslunr=707</lífshlaup>
+                        <hagsmunir>http://www.althingi.is/altext/hagsmunir/?faerslunr=707</hagsmunir>
+                        <þingstörf>http://www.althingi.is/vefur/thmstorf.html?nfaerslunr=707</þingstörf>
+                    </html>
+                </ráðherra>
+            </ráðherralisti>';
+        $dom = new \DOMDocument();
+        $dom->loadXML($source);
+        return $dom;
+    }
+
+    public function getMinisterSession()
+    {
+        $source = '<?xml version="1.0" encoding="UTF-8"?>
+                <einstaklingur id=\'1261\'>
+                <nafn>Áslaug Arna Sigurbjörnsdóttir</nafn>
+                <xml>
+                <lífshlaup>http://www.althingi.is/altext/xml/thingmenn/thingmadur/lifshlaup/?nr=1261</lífshlaup>
+                <hagsmunir>http://www.althingi.is/altext/xml/thingmenn/thingmadur/hagsmunir/?nr=1261</hagsmunir>
+                <þingseta>http://www.althingi.is/altext/xml/thingmenn/thingmadur/thingseta/?nr=1261</þingseta>
+                <ráðherraseta>http://www.althingi.is/altext/xml/radherrar/radherraseta/?nr=1261</ráðherraseta>
+                </xml>
+                <html>
+                <lífshlaup>http://www.althingi.is/altext/cv/?nfaerslunr=1261</lífshlaup>
+                <hagsmunir>http://www.althingi.is/altext/hagsmunir/?faerslunr=1261</hagsmunir>
+                <þingstörf>http://www.althingi.is/vefur/thmstorf.html?nfaerslunr=1261</þingstörf>
+                </html>
+                
+                <ráðherrasetur>
+                <ráðherraseta>
+                <þing>149</þing>
+                <skammstöfun>ÁslS</skammstöfun>
+                <embætti id=\'224\'>dómsmálaráðherra</embætti>
+                <þingflokkur id=\'35\'>Sjálfstæðisflokkur</þingflokkur>
+                <tímabil>
+                <inn>06.09.2019</inn><út>09.09.2019</út></tímabil>
+                </ráðherraseta>
+                
+                <ráðherraseta>
+                <þing>150</þing>
+                <skammstöfun>ÁslS</skammstöfun>
+                <embætti id=\'224\'>dómsmálaráðherra</embætti>
+                <þingflokkur id=\'35\'>Sjálfstæðisflokkur</þingflokkur>
+                <tímabil>
+                <inn>10.09.2019</inn><út></út></tímabil>
+                </ráðherraseta>
+                
+                </ráðherrasetur>
+                </einstaklingur>
+                ';
         $dom = new \DOMDocument();
         $dom->loadXML($source);
         return $dom;

--- a/module/AlthingiAggregator/tests/Controller/MinistryControllerTest.php
+++ b/module/AlthingiAggregator/tests/Controller/MinistryControllerTest.php
@@ -1,0 +1,97 @@
+<?php
+namespace AlthingiAggregatorTest\Controller;
+
+use AlthingiAggregator\Controller\MinistryController;
+use AlthingiAggregatorTest\Lib\Consumer\TestConsumer;
+use AlthingiAggregatorTest\Lib\Provider\TestProvider;
+use Zend\Test\PHPUnit\Controller\AbstractConsoleControllerTestCase;
+use Zend\Stdlib\ArrayUtils;
+
+class MinistryControllerTest extends AbstractConsoleControllerTestCase
+{
+    /** @var  TestConsumer */
+    private $consumer;
+
+    /** @var  TestProvider */
+    private $provider;
+
+    public function setUp()
+    {
+        $configOverrides = [];
+
+        $this->setApplicationConfig(ArrayUtils::merge(
+            include __DIR__ . '/../../../../config/application.config.php',
+            $configOverrides
+        ));
+
+        parent::setUp();
+
+        $this->provider = new TestProvider();
+        $this->consumer = new TestConsumer();
+
+        $serviceManager = $this->getApplicationServiceLocator();
+        $serviceManager->setAllowOverride(true);
+        $serviceManager->setService('Provider', $this->provider);
+        $serviceManager->setService('Consumer', $this->consumer);
+    }
+
+    public function testMinistryRoute()
+    {
+        $this->provider->addDocument(
+            'https://www.althingi.is/altext/xml/radherraembaetti',
+            $this->getDomDocument()
+        );
+
+        $this->dispatch('load:ministry');
+
+        $consumerStoredData = $this->consumer->getObjects();
+
+        $this->assertCount(3, $consumerStoredData);
+        $this->assertControllerName(MinistryController::class);
+        $this->assertActionName('find-ministry');
+    }
+
+    public function getDomDocument()
+    {
+        $source = '<?xml version="1.0" encoding="UTF-8"?>
+            <ráðherrar>
+                <ráðherraembætti id="123">
+                    <heiti> atvinnumálaráðherra </heiti>
+                    <skammstafanir>
+                        <stuttskammstöfun>atvmrh.</stuttskammstöfun>
+                        <löngskammstöfun>atvinnumálarh.</löngskammstöfun>
+                    </skammstafanir>
+                    <tímabil>
+                        <fyrstaþing>1</fyrstaþing>
+                        <síðastaþing>100</síðastaþing>
+                    </tímabil>
+                </ráðherraembætti>
+                <ráðherraembætti id="208">
+                    <heiti> atvinnuvega- og nýsköpunarráðherra </heiti>
+                    <skammstafanir>
+                        <stuttskammstöfun>atvvrh.</stuttskammstöfun>
+                        <löngskammstöfun>atv.- og nýskrh.</löngskammstöfun>
+                    </skammstafanir>
+                    <tímabil>
+                        <fyrstaþing>140</fyrstaþing>
+                        <síðastaþing>141</síðastaþing>
+                    </tímabil>
+                </ráðherraembætti>
+                <ráðherraembætti id="186">
+                    <heiti> dómsmála- og mannréttindaráðherra </heiti>
+                    <skammstafanir>
+                        <stuttskammstöfun>dómsmrh.</stuttskammstöfun>
+                        <löngskammstöfun>dómsmálarh.</löngskammstöfun>
+                    </skammstafanir>
+                    <tímabil>
+                        <fyrstaþing>138</fyrstaþing>
+                        <síðastaþing>139</síðastaþing>
+                    </tímabil>
+                </ráðherraembætti>
+            </ráðherrar>
+            ';
+        $dom = new \DOMDocument();
+        $dom->loadXML($source);
+        return $dom;
+    }
+}

--- a/module/AlthingiAggregator/tests/Extractor/MinisterSittingTest.php
+++ b/module/AlthingiAggregator/tests/Extractor/MinisterSittingTest.php
@@ -1,0 +1,133 @@
+<?php
+namespace AlthingiAggregatorTest\Extractor;
+
+use AlthingiAggregator\Extractor\CommitteeSitting;
+use AlthingiAggregator\Extractor\MinisterSitting;
+use PHPUnit\Framework\TestCase;
+use DOMDocument;
+
+class MinisterSittingTest extends TestCase
+{
+    public function testWithAllData()
+    {
+        $expectedData = [
+            'assembly_id' => 149,
+            'ministry_id' => 224,
+            'party_id' => 35,
+            'from' => '2019-09-06',
+            'to' => '2019-09-09',
+        ];
+        $extractor = new MinisterSitting();
+
+        /** @var  $element |DOMElement */
+        $element = $this->getDocument()->getElementsByTagName('ráðherraseta')->item(0);
+
+        $resultedData = $extractor->extract($element);
+
+        $this->assertEquals($expectedData, $resultedData);
+    }
+
+    public function testWithNoToDate()
+    {
+        $expectedData = [
+            'assembly_id' => 149,
+            'ministry_id' => 224,
+            'party_id' => 35,
+            'from' => '2019-09-06',
+            'to' => null,
+        ];
+        $extractor = new MinisterSitting();
+
+        /** @var  $element |DOMElement */
+        $element = $this->getDocument()->getElementsByTagName('ráðherraseta')->item(1);
+
+        $resultedData = $extractor->extract($element);
+
+        $this->assertEquals($expectedData, $resultedData);
+    }
+
+    public function testWithMissingToDate()
+    {
+        $expectedData = [
+            'assembly_id' => 149,
+            'ministry_id' => 224,
+            'party_id' => 35,
+            'from' => '2019-09-06',
+            'to' => null,
+        ];
+        $extractor = new MinisterSitting();
+
+        /** @var  $element |DOMElement */
+        $element = $this->getDocument()->getElementsByTagName('ráðherraseta')->item(2);
+
+        $resultedData = $extractor->extract($element);
+
+        $this->assertEquals($expectedData, $resultedData);
+    }
+
+    public function testWithMissingParty()
+    {
+        $expectedData = [
+            'assembly_id' => 149,
+            'ministry_id' => 224,
+            'party_id' => null,
+            'from' => '2019-09-06',
+            'to' => null,
+        ];
+        $extractor = new MinisterSitting();
+
+        /** @var  $element |DOMElement */
+        $element = $this->getDocument()->getElementsByTagName('ráðherraseta')->item(3);
+
+        $resultedData = $extractor->extract($element);
+
+        $this->assertEquals($expectedData, $resultedData);
+    }
+
+    private function getDocument()
+    {
+        $source = '<?xml version="1.0" encoding="UTF-8"?>
+            <root>
+                <ráðherraseta>
+                    <þing>149</þing>
+                    <skammstöfun>ÁslS</skammstöfun>
+                    <embætti id="224">dómsmálaráðherra</embætti>
+                    <þingflokkur id="35">Sjálfstæðisflokkur</þingflokkur>
+                    <tímabil>
+                        <inn>06.09.2019</inn>
+                        <út>09.09.2019</út>
+                    </tímabil>
+                </ráðherraseta>
+                <ráðherraseta>
+                    <þing>149</þing>
+                    <skammstöfun>ÁslS</skammstöfun>
+                    <embætti id="224">dómsmálaráðherra</embætti>
+                    <þingflokkur id="35">Sjálfstæðisflokkur</þingflokkur>
+                    <tímabil>
+                        <inn>06.09.2019</inn>
+                        <út></út>
+                    </tímabil>
+                </ráðherraseta>
+                <ráðherraseta>
+                    <þing>149</þing>
+                    <skammstöfun>ÁslS</skammstöfun>
+                    <embætti id="224">dómsmálaráðherra</embætti>
+                    <þingflokkur id="35">Sjálfstæðisflokkur</þingflokkur>
+                    <tímabil>
+                        <inn>06.09.2019</inn>
+                    </tímabil>
+                </ráðherraseta>
+                <ráðherraseta>
+                    <þing>149</þing>
+                    <skammstöfun>ÁslS</skammstöfun>
+                    <embætti id="224">dómsmálaráðherra</embætti>
+                    <tímabil>
+                        <inn>06.09.2019</inn>
+                    </tímabil>
+                </ráðherraseta>
+            </root>';
+        $dom = new DOMDocument();
+        $dom->loadXML($source);
+        return $dom;
+    }
+}

--- a/module/AlthingiAggregator/tests/Extractor/MinistryTest.php
+++ b/module/AlthingiAggregator/tests/Extractor/MinistryTest.php
@@ -1,0 +1,110 @@
+<?php
+namespace AlthingiAggregatorTest\Extractor;
+
+use AlthingiAggregator\Extractor\CommitteeSitting;
+use AlthingiAggregator\Extractor\MinisterSitting;
+use AlthingiAggregator\Extractor\Ministry;
+use PHPUnit\Framework\TestCase;
+use DOMDocument;
+
+class MinistryTest extends TestCase
+{
+    public function testWithAllData()
+    {
+        $expectedData = [
+            'ministry_id' => 123,
+            'name' => 'atvinnumálaráðherra',
+            'abbr_short' => 'atvmrh.',
+            'abbr_slong' => 'atvinnumálarh.',
+            'first' => 1,
+            'last' => 100,
+        ];
+        $extractor = new Ministry();
+
+        /** @var  $element |DOMElement */
+        $element = $this->getDocument()->getElementsByTagName('ráðherraembætti')->item(0);
+
+        $resultedData = $extractor->extract($element);
+
+        $this->assertEquals($expectedData, $resultedData);
+    }
+
+    public function testWithNoAbbr()
+    {
+        $expectedData = [
+            'ministry_id' => 123,
+            'name' => 'atvinnumálaráðherra',
+            'abbr_short' => null,
+            'abbr_slong' => null,
+            'first' => 1,
+            'last' => 100,
+        ];
+        $extractor = new Ministry();
+
+        /** @var  $element |DOMElement */
+        $element = $this->getDocument()->getElementsByTagName('ráðherraembætti')->item(1);
+
+        $resultedData = $extractor->extract($element);
+
+        $this->assertEquals($expectedData, $resultedData);
+    }
+
+    public function testWithNoLast()
+    {
+        $expectedData = [
+            'ministry_id' => 123,
+            'name' => 'atvinnumálaráðherra',
+            'abbr_short' => 'atvmrh.',
+            'abbr_slong' => 'atvinnumálarh.',
+            'first' => 1,
+            'last' => null,
+        ];
+        $extractor = new Ministry();
+
+        /** @var  $element |DOMElement */
+        $element = $this->getDocument()->getElementsByTagName('ráðherraembætti')->item(2);
+
+        $resultedData = $extractor->extract($element);
+
+        $this->assertEquals($expectedData, $resultedData);
+    }
+
+    private function getDocument()
+    {
+        $source = '<?xml version="1.0" encoding="UTF-8"?>
+            <ráðherrar>
+                <ráðherraembætti id="123">
+                    <heiti> atvinnumálaráðherra </heiti>
+                    <skammstafanir>
+                        <stuttskammstöfun>atvmrh.</stuttskammstöfun>
+                        <löngskammstöfun>atvinnumálarh.</löngskammstöfun>
+                    </skammstafanir>
+                    <tímabil>
+                        <fyrstaþing>1</fyrstaþing>
+                        <síðastaþing>100</síðastaþing>
+                    </tímabil>
+                </ráðherraembætti>
+                <ráðherraembætti id="123">
+                    <heiti> atvinnumálaráðherra </heiti>
+                    <tímabil>
+                        <fyrstaþing>1</fyrstaþing>
+                        <síðastaþing>100</síðastaþing>
+                    </tímabil>
+                </ráðherraembætti>
+                <ráðherraembætti id="123">
+                    <heiti> atvinnumálaráðherra </heiti>
+                    <skammstafanir>
+                        <stuttskammstöfun>atvmrh.</stuttskammstöfun>
+                        <löngskammstöfun>atvinnumálarh.</löngskammstöfun>
+                    </skammstafanir>
+                    <tímabil>
+                        <fyrstaþing>1</fyrstaþing>
+                        <síðastaþing></síðastaþing>
+                    </tímabil>
+                </ráðherraembætti>
+            </ráðherrar>';
+        $dom = new DOMDocument();
+        $dom->loadXML($source);
+        return $dom;
+    }
+}


### PR DESCRIPTION
## What?
People can be ministers without being congressmen. When they then do something in parliament, the system will now know about them (they are not in the congressman list). To tackle some of the 404 errors, this PR pulls in the list of ministers (which sometimes are congressmen as well).

As well this PR pulls in the list of ministries 

## How?
## Why?