### PR TITLE
Adds scraper for committee documents

### DIFF
--- a/module/AlthingiAggregator/src/Controller/IssueController.php
+++ b/module/AlthingiAggregator/src/Controller/IssueController.php
@@ -79,9 +79,6 @@ class IssueController extends AbstractActionController implements
      * @param $issueNumber
      * @param DOMXPath $xPath
      * @throws \Exception
-     * @todo The `samantekt` can be empty
-     *  https://www.althingi.is/altext/xml/samantektir/samantekt/?lthing=141&malnr=1
-     *  <samantekt><!--  engin samantekt  --></samantekt>
      */
     private function processIssue($assemblyNumber, $issueNumber, DOMXPath $xPath)
     {
@@ -178,13 +175,22 @@ class IssueController extends AbstractActionController implements
             $documentsDom = $this->queryForDocument($documentNodeElement->nodeValue);
             $documentsXPath = new DOMXPath($documentsDom);
             $documentId = $documentsXPath->query('//þingskjal/þingskjal')->item(0)->getAttribute('skjalsnúmer');
-            $congressmenNodeList = $documentsXPath->query('//þingskjal/þingskjal/flutningsmenn/flutningsmaður');
+            $congressmenNodeList = $documentsXPath->query('//þingskjal/þingskjal/flutningsmenn//flutningsmaður');
 
             foreach ($congressmenNodeList as $congressman) {
                 $this->saveDomElement(
                     $congressman,
                     "loggjafarthing/{$assemblyNumber}/thingmal/a/{$issueNumber}/thingskjal/{$documentId}/flutningsmenn",
                     new Extractor\Proponent()
+                );
+            }
+
+            $committeesNodeList = $documentsXPath->query('//þingskjal/þingskjal/flutningsmenn//nefnd');
+            foreach ($committeesNodeList as $committee) {
+                $this->saveDomElement(
+                    $committee,
+                    "loggjafarthing/{$assemblyNumber}/thingmal/a/{$issueNumber}/thingskjal/{$documentId}/nefndir",
+                    new Extractor\DocumentCommittee()
                 );
             }
         }

--- a/module/AlthingiAggregator/src/Extractor/DocumentCommittee.php
+++ b/module/AlthingiAggregator/src/Extractor/DocumentCommittee.php
@@ -1,0 +1,35 @@
+<?php
+namespace AlthingiAggregator\Extractor;
+
+use DOMElement;
+use AlthingiAggregator\Extractor;
+
+class DocumentCommittee implements ExtractionInterface
+{
+    /**
+     * Extract values from an object
+     *
+     * @param  DOMElement $object
+     * @return array
+     * @throws \AlthingiAggregator\Extractor\Exception
+     */
+    public function extract(DOMElement $object)
+    {
+        if (! $object->hasAttribute('id')) {
+            throw new Extractor\Exception('Missing [{id}] value', $object);
+        }
+
+        $part = $object->getElementsByTagName('hluti')->length
+            ? trim($object->getElementsByTagName('hluti')->item(0)->nodeValue)
+            : null;
+        $name = $object->getElementsByTagName('heiti')->item(0)
+            ? trim($object->getElementsByTagName('heiti')->item(0)->nodeValue)
+            : null;
+
+        return [
+            'committee_id' => (int) $object->getAttribute('id'),
+            'part' => $part,
+            'name' => $name,
+        ];
+    }
+}

--- a/module/AlthingiAggregator/tests/Controller/IssueControllerTest.php
+++ b/module/AlthingiAggregator/tests/Controller/IssueControllerTest.php
@@ -34,8 +34,8 @@ class IssueControllerTest extends AbstractConsoleControllerTestCase
     public function testNotShowingUp()
     {
         $this->assertTrue(true);
-
-//        $this->dispatch('load:single-issue --assembly=142  --issue=1  --category=A');
+//
+//        $this->dispatch('load:single-issue --assembly=143  --issue=1  --category=A');
 //
 //        $consumerStoredData = $this->consumer->getObjects();
 //

--- a/module/AlthingiAggregator/tests/Extractor/DocumentCommitteeTest.php
+++ b/module/AlthingiAggregator/tests/Extractor/DocumentCommitteeTest.php
@@ -1,0 +1,78 @@
+<?php
+namespace AlthingiAggregatorTest\Extractor;
+
+use AlthingiAggregator\Extractor\DocumentCommittee;
+use PHPUnit\Framework\TestCase;
+use DOMDocument;
+
+class DocumentCommitteeTest extends TestCase
+{
+    public function testValidDocument()
+    {
+        $expectedData = [
+            'committee_id' => 207,
+            'part' => '4. minni hluti',
+            'name' => 'fjárlaganefnd',
+        ];
+        $dom = new DOMDocument();
+        $dom->loadXML("<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+            <nefnd id=\"207\">
+                   <hluti>4. minni hluti</hluti>
+                   <heiti>fjárlaganefnd</heiti>
+                   <flutningsmaður id=\"1334\" röð=\"1\">
+                      <nafn>Ólafur Ísleifsson</nafn>
+                      <xml>http://www.althingi.is/altext/xml/thingmenn/thingmadur/?nr=1334</xml>
+                   </flutningsmaður>
+                </nefnd>
+        ");
+
+        $documentData = (new DocumentCommittee())
+            ->extract($dom->firstChild);
+
+        $this->assertEquals($expectedData, $documentData);
+    }
+    public function testMissingParts()
+    {
+        $expectedData = [
+            'committee_id' => 207,
+            'part' => null,
+            'name' => null,
+        ];
+        $dom = new DOMDocument();
+        $dom->loadXML("<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+            <nefnd id=\"207\">
+                   <flutningsmaður id=\"1334\" röð=\"1\">
+                      <nafn>Ólafur Ísleifsson</nafn>
+                      <xml>http://www.althingi.is/altext/xml/thingmenn/thingmadur/?nr=1334</xml>
+                   </flutningsmaður>
+                </nefnd>
+        ");
+
+        $documentData = (new DocumentCommittee())
+            ->extract($dom->firstChild);
+
+        $this->assertEquals($expectedData, $documentData);
+    }
+
+    /**
+     * @expectedException \AlthingiAggregator\Extractor\Exception
+     */
+    public function testMissingId()
+    {
+        $dom = new DOMDocument();
+        $dom->loadXML("<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+            <nefnd>
+                   <hluti>4. minni hluti</hluti>
+                   <heiti>fjárlaganefnd</heiti>
+                   <flutningsmaður id=\"1334\" röð=\"1\">
+                      <nafn>Ólafur Ísleifsson</nafn>
+                      <xml>http://www.althingi.is/altext/xml/thingmenn/thingmadur/?nr=1334</xml>
+                   </flutningsmaður>
+                </nefnd>
+        ");
+
+        $documentData = (new DocumentCommittee())
+            ->extract($dom->firstChild);
+    }
+
+}

--- a/module/AlthingiAggregator/tests/Extractor/DocumentCommitteeTest.php
+++ b/module/AlthingiAggregator/tests/Extractor/DocumentCommitteeTest.php
@@ -74,5 +74,4 @@ class DocumentCommitteeTest extends TestCase
         $documentData = (new DocumentCommittee())
             ->extract($dom->firstChild);
     }
-
 }


### PR DESCRIPTION
## What?
Collects which committee issued which document (if the document came from a committee)

## How?
Adds to the `processProponents` method to get all proponents (even the one part of a committee)
Get the committee and sends that into via the `"loggjafarthing/{$assemblyNumber}/thingmal/a/{$issueNumber}/thingskjal/{$documentId}/nefndir"` url

## Why?
So we have info on which committee is issuing which document.